### PR TITLE
Window height fix for safari mobile

### DIFF
--- a/src/infinite-scroll.coffee
+++ b/src/infinite-scroll.coffee
@@ -35,10 +35,11 @@ mod.directive 'infiniteScroll', ['$rootScope', '$window', '$timeout', ($rootScop
     # with a boolean that is set to true when the function is
     # called in order to throttle the function call.
     handler = ->
-      windowBottom = $window.height() + $window.scrollTop()
+      windowHeight = (if window.innerHeight isnt `undefined` then window.innerHeight else $window.height())
+      windowBottom = windowHeight + $window.scrollTop()
       elementBottom = elem.offset().top + elem.height()
       remaining = elementBottom - windowBottom
-      shouldScroll = remaining <= $window.height() * scrollDistance
+      shouldScroll = remaining <= windowHeight * scrollDistance
 
       if shouldScroll && scrollEnabled
         if $rootScope.$$phase


### PR DESCRIPTION
When viewing a page with safari from an iphone device, the window height is not calculated properly because of the iphone's address bar height. 
A simple fix would be use the window.innerHeight value if present. Otherwise use $window.height()
