### PR TITLE
allow scroll to be scoped inside of the window

### DIFF
--- a/build/ng-infinite-scroll.js
+++ b/build/ng-infinite-scroll.js
@@ -43,6 +43,7 @@ mod.directive('infiniteScroll', [
           }
         };
         $window.on('scroll', handler);
+        elem.on('scroll', handler);
         scope.$on('$destroy', function() {
           return $window.off('scroll', handler);
         });


### PR DESCRIPTION
allow for scrolling events on that do not take up the entire window.  Note: your infinite scroll declaration will have to take place on whatever div you want it scoped to.  Fixes #34 probably some others
