### PR TITLE
Added trigger variable to allow scroll checks to be fired from the model.

### DIFF
--- a/src/infinite-scroll.coffee
+++ b/src/infinite-scroll.coffee
@@ -10,6 +10,7 @@ mod.directive 'infiniteScroll', ['$rootScope', '$window', '$timeout', 'THROTTLE_
     infiniteScrollDistance: '='
     infiniteScrollDisabled: '='
     infiniteScrollUseDocumentBottom: '='
+    infiniteScrollTrigger: '='
 
   link: (scope, elem, attrs) ->
     $window = angular.element($window)
@@ -154,6 +155,11 @@ mod.directive 'infiniteScroll', ['$rootScope', '$window', '$timeout', 'THROTTLE_
         throw new Exception("invalid infinite-scroll-container attribute.")
 
     scope.$watch 'infiniteScrollContainer', handleInfiniteScrollContainer
+
+    scope.$watch('infiniteScrollTrigger', (newVal, oldVal)->
+      if newVal isnt oldVal then $timeout(handler)
+    )
+
     handleInfiniteScrollContainer(scope.infiniteScrollContainer or [])
 
     # infinite-scroll-parent establishes this element's parent as the

--- a/test/test_infinite_scroll.coffee
+++ b/test/test_infinite_scroll.coffee
@@ -153,6 +153,60 @@ describe 'Infinite Scroll', ->
       el.remove()
       scope.$destroy()
 
+
+    'triggers when infinite-scroll-trigger changes': (scroller, container, injScope) ->
+      el = angular.element(scroller)
+      $document.append(el)
+
+      isWindow = true unless container?
+      if not isWindow
+        container.height(1000)
+      else
+        sinon.stub(fakeWindow, 'height').returns(1000)
+        container = fakeWindow
+
+      scope = $rootScope.$new(true)
+      for k, v of injScope
+        scope[k] = v
+      scope.scroll = sinon.spy()
+      scope.scrollTrigger = 1;
+      $compile(el)(scope)
+      $timeout.flush() # 'immediate' call is with $timeout ..., 0
+      scope.scrollTrigger++
+      scope.$digest()
+      $timeout.flush() # 'trigger' call is with $timeout ..., 0
+      scope.scroll.should.have.been.calledOnce
+
+      el.remove()
+      scope.$destroy()
+
+    'does not trigger when infinite-scroll-trigger changes if disabled': (scroller, container, injScope) ->
+      el = angular.element(scroller)
+      $document.append(el)
+
+      isWindow = true unless container?
+      if not isWindow
+        container.height(1000)
+      else
+        sinon.stub(fakeWindow, 'height').returns(1000)
+        container = fakeWindow
+
+      scope = $rootScope.$new(true)
+      for k, v of injScope
+        scope[k] = v
+      scope.scroll = sinon.spy()
+      scope.scrollTrigger = 0;
+      scope.busy = true
+      $compile(el)(scope)
+      $timeout.flush() # 'immediate' call is with $timeout ..., 0
+      scope.scrollTrigger++
+      scope.$digest()
+      $timeout.verifyNoPendingTasks # 'trigger' call is with $timeout ..., 0
+      scope.scroll.should.not.have.been.calledOnce
+
+      el.remove()
+      scope.$destroy()
+
     'only triggers when the container has been sufficiently scrolled down': (scroller, container, injScope) ->
       el = angular.element(scroller)
       $document.append(el)
@@ -247,6 +301,14 @@ describe 'Infinite Scroll', ->
         infinite-scroll-disabled='busy' style='height: 500px;'></div>
       """
 
+    'triggers when infinite-scroll-trigger changes': -> """
+      <div infinite-scroll='scroll()' infinite-scroll-distance='1'
+      infinite-scroll-immediate-check='false'  infinite-scroll-trigger='scrollTrigger' style='height: 500px;'></div>
+      """
+    'does not trigger when infinite-scroll-trigger changes if disabled': -> """
+      <div infinite-scroll='scroll()' infinite-scroll-distance='1'
+       infinite-scroll-immediate-check='false' infinite-scroll-trigger='scrollTrigger' infinite-scroll-disabled='busy' style='height: 500px;'></div>
+      """
     'only triggers when the container has been sufficiently scrolled down': -> """
       <div infinite-scroll='scroll()'
         infinite-scroll-distance='1' style='height: 10000px'></div>


### PR DESCRIPTION
This is to allow the checking handler to be 'poked' when content of the scroll area is changed for reasons other than the infinite scroll mechanism (such as filters being applied etc).

The implementation I went with uses a zero timeout. This is to prevent an issue in what I would assume would be a common use case, that being specifying data array used by an ng-repeat (for instance) in the infinite scroll area as the trigger.

Without the timeout, if the scroll handler rereferences this same array, it can get into a cycle where it continuously triggers the scroll handler because the DOM doesn't get chance to update to a state where ngInfiniteScroll can infer that more data is no longer required.
