### PR TITLE
do not trigger action when element is hidden

### DIFF
--- a/src/infinite-scroll.coffee
+++ b/src/infinite-scroll.coffee
@@ -28,6 +28,9 @@ mod.directive 'infiniteScroll', ['$rootScope', '$window', '$interval', 'THROTTLE
 
       if isNaN(elem.offsetHeight) then elem.document.documentElement.clientHeight else elem.offsetHeight
 
+    isVisible = (elem) ->
+      elem[0].offsetWidth and elem[0].offsetHeight
+
     offsetTop = (elem) ->
       if not elem[0].getBoundingClientRect or elem.css('none')
         return
@@ -46,21 +49,24 @@ mod.directive 'infiniteScroll', ['$rootScope', '$window', '$interval', 'THROTTLE
     # with a boolean that is set to true when the function is
     # called in order to throttle the function call.
     handler = ->
-      if container == windowElement
-        containerBottom = height(container) + pageYOffset(container[0].document.documentElement)
-        elementBottom = offsetTop(elem) + height(elem)
+      if isVisible(elem)
+        if container == windowElement
+          containerBottom = height(container) + pageYOffset(container[0].document.documentElement)
+          elementBottom = offsetTop(elem) + height(elem)
+        else
+          containerBottom = height(container)
+          containerTopOffset = 0
+          if offsetTop(container) != undefined
+            containerTopOffset = offsetTop(container)
+          elementBottom = offsetTop(elem) - containerTopOffset + height(elem)
+
+        if(useDocumentBottom)
+          elementBottom = height((elem[0].ownerDocument || elem[0].document).documentElement)
+
+        remaining = elementBottom - containerBottom
+        shouldScroll = remaining <= height(container) * scrollDistance + 1
       else
-        containerBottom = height(container)
-        containerTopOffset = 0
-        if offsetTop(container) != undefined
-          containerTopOffset = offsetTop(container)
-        elementBottom = offsetTop(elem) - containerTopOffset + height(elem)
-
-      if(useDocumentBottom)
-        elementBottom = height((elem[0].ownerDocument || elem[0].document).documentElement)
-
-      remaining = elementBottom - containerBottom
-      shouldScroll = remaining <= height(container) * scrollDistance + 1
+        shouldScroll = false
 
       if shouldScroll
         checkWhenEnabled = true

--- a/test/spec/ng-infinite-scroll.spec.coffee
+++ b/test/spec/ng-infinite-scroll.spec.coffee
@@ -9,6 +9,9 @@ getTemplate = (angularVersion, container, attrs, throttle) ->
         html, body {
           height: 100%;
         }
+        [infinite-scroll] {
+          min-height: 50px;
+        }
       </style>
       <script src='http://ajax.googleapis.com/ajax/libs/angularjs/#{angularVersion}/angular.min.js'></script>
       <script src="../../build/ng-infinite-scroll.js"></script>
@@ -149,6 +152,11 @@ describe "ng-infinite-scroll", ->
               expect(getItems().count()).toBe 100
               browser.driver.executeScript(scrollToLastScreenScript(container, 20))
               expect(getItems().count()).toBe 200
+
+            it "do not trigger when element is invisible", -> 
+              replaceIndexFile "style='display: none;'", throttle
+              browser.get pathToDocument
+              expect(getItems().count()).toBe 0
 
             describe "with an event handler", ->
 


### PR DESCRIPTION
It can be useful sometimes.
For example I have a set of tabs. One of tabs have a list with infinite scroll. Now scroll will be triggered anyway, even this tab is hidden. The fix resolves this issue and data will be loaded just when it's really needed
