### PR TITLE
Don't forget to cancel the checkInterval

### DIFF
--- a/src/infinite-scroll.coffee
+++ b/src/infinite-scroll.coffee
@@ -108,6 +108,8 @@ mod.directive 'infiniteScroll', ['$rootScope', '$window', '$interval', 'THROTTLE
       if unregisterEventListener?
         unregisterEventListener()
         unregisterEventListener = null
+      if checkInterval 
+        $interval.cancel checkInterval
 
     # infinite-scroll-distance specifies how close to the bottom of the page
     # the window is allowed to be before we trigger a new scroll. The value


### PR DESCRIPTION
If immediateCheck == false and user navigates to another state without performing a scroll, in a page where the directive is used, the checkInterval won't get cancelled and will keep invoking $apply() infinitely.