### PR TITLE
fix infinite loop when scrolling end

### DIFF
--- a/src/infinite-scroll.coffee
+++ b/src/infinite-scroll.coffee
@@ -67,6 +67,7 @@ mod.directive 'infiniteScroll', ['$rootScope', '$window', '$interval', 'THROTTLE
         checkWhenEnabled = true
 
         if scrollEnabled
+          checkWhenEnabled = false    
           if scope.$$phase || $rootScope.$$phase
             scope.infiniteScroll()
           else


### PR DESCRIPTION
The problem has been stated in issue #186 , I found out the infinite loop will occur when using AJAX calls to retrieve data which normally requires the use of `infinite-scroll-disabled`. When its value switches from true to false, it will trigger scroll function again if `checkWhenEnabled` is true. 
`handleInfiniteScrollDisabled = (v) ->
      scrollEnabled = !v
      if scrollEnabled && checkWhenEnabled
        checkWhenEnabled = false
        handler()`
In the handler() function:
`if shouldScroll
        checkWhenEnabled = true  
        if scrollEnabled
          if scope.$$phase || $rootScope.$$phase
            scope.infiniteScroll()
          else
            scope.$apply(scope.infiniteScroll)
      else
        checkWhenEnabled = false`
if shouldScroll is always true (when scroll to then end), then checkWhenEnabled is also always true. When we toggle `infinite-scroll-disabled` in our infinite scroll function, 'handler()' will be constantly triggered by `handleInfiniteScrollDisabled()` causing infinite scroll function jumps into infinite loop.
I think `checkWhenEnabled` should be set back to false if the infinite scroll function is able to be triggered in `handler()` so there is no need for `handleInfiniteScrollDisabled` to trigger it again:
`if shouldScroll
        checkWhenEnabled = true  
        if scrollEnabled
          checkWhenEnabled = false
          if scope.$$phase || $rootScope.$$phase
            scope.infiniteScroll()
          else
            scope.$apply(scope.infiniteScroll)
      else
        checkWhenEnabled = false`
It works for me.