### PR TITLE
Add jquery dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,7 @@
         ".*"
     ],
     "dependencies": {
-        "angular": ">=1.2.0"
+        "angular": ">=1.2.0",
+        "jquery": "latest"
     }
 }


### PR DESCRIPTION
"$window.height  is not a function" error is triggered because Jquery is not loaded first. This was because it was not listed as a dependency.