### PR TITLE
Set $apply execution as optional parameter

### DIFF
--- a/src/infinite-scroll.js
+++ b/src/infinite-scroll.js
@@ -15,6 +15,7 @@ angular.module(MODULE_NAME, [])
       infiniteScrollDisabled: '=',
       infiniteScrollUseDocumentBottom: '=',
       infiniteScrollListenForEvent: '@',
+      infiniteScrollExecuteApply: '=',
     },
 
     link(scope, elem, attrs) {
@@ -28,6 +29,11 @@ angular.module(MODULE_NAME, [])
       let useDocumentBottom = false;
       let unregisterEventListener = null;
       let checkInterval = false;
+      let infiniteScrollExecuteApply = true;
+
+      if (scope.infiniteScrollExecuteApply !== undefined) {
+        infiniteScrollExecuteApply = !!scope.infiniteScrollExecuteApply;
+      }
 
       function height(element) {
         const el = element[0] || element;
@@ -86,7 +92,7 @@ angular.module(MODULE_NAME, [])
           checkWhenEnabled = true;
 
           if (scrollEnabled) {
-            if (scope.$$phase || $rootScope.$$phase) {
+            if (scope.$$phase || $rootScope.$$phase || !infiniteScrollExecuteApply) {
               scope.infiniteScroll();
             } else {
               scope.$apply(scope.infiniteScroll);

--- a/test/spec/ng-infinite-scroll.spec.coffee
+++ b/test/spec/ng-infinite-scroll.spec.coffee
@@ -169,7 +169,7 @@ describe "ng-infinite-scroll", ->
               expect(getItems().count()).toBe 200
 
             it "renders new items if infinite-scroll-execute-apply is set to false and we call $apply outside the handler", ->
-              replaceIndexFile "infinite-scroll-execute-apply='true'", throttle, true
+              replaceIndexFile "infinite-scroll-execute-apply='false'", throttle, true
               browser.get pathToDocument
               expect(getItems().count()).toBe 100
               browser.driver.executeScript(scrollToBottomScript(container))


### PR DESCRIPTION
The intention is to have an option to manage when angular digest is executed. This is for performance purposes. 
In our application we use this library having tons of bindings so a digest flow can take long. Would be nice to have the possibility to execute digest wherever and whenever we want.

We have created a branch adding a new parameter where you can set avoiding the explicit call on $apply().