### PR TITLE
Improved detecting whether container is `window`

### DIFF
--- a/src/infinite-scroll.js
+++ b/src/infinite-scroll.js
@@ -63,7 +63,7 @@ angular.module(MODULE_NAME, [])
       function defaultHandler() {
         let containerBottom;
         let elementBottom;
-        if (container === windowElement) {
+        if (container[0] === $window) {
           containerBottom = height(container) + pageYOffset(container[0].document.documentElement);
           elementBottom = offsetTop(elem) + height(elem);
         } else {


### PR DESCRIPTION
It's impossible now to change container back to `window` from external code. This fixes the issue. Here is a use case example: one has a responsive web page, and wants infinite scroll bind to window at low resolution but bind to an HTML element at high resolution. There should be a way to switch between these two containers dynamically on window resize.