### PR TITLE
Massive Performance Issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "load-grunt-tasks": "^3.5.0",
     "mkdirp": "0.5.0",
     "protractor": "1.4.0",
-    "sauce-connect-launcher": "0.9.0"
+    "sauce-connect-launcher": "1.1.1"
   },
   "peerDependencies": {
     "angular": "^1.2"


### PR DESCRIPTION
I noticed that infinite scroll is actually causing a digest to get fired every 20 ms. This is really painful for websites since it's causing that digest cycle continously. I changed the following 2 lines locally and the performance was infinitely better both for actual scrolling performance, and in the timeline.

My car got broken into yesterday, so I'm totally doing this off my phone, but I can post a better diff soon. One thing to note is that when I tried to do this in my fork, a lot of the tests failed. 

Ignore the first 3 files. I was trying to get protractor and travis to work with my fork and changed all values I can think off. Eventually it did. 