### PR TITLE
Don't trigger infinite scroll events when container is hidden

### DIFF
--- a/src/infinite-scroll.js
+++ b/src/infinite-scroll.js
@@ -47,6 +47,10 @@ angular.module(MODULE_NAME, [])
         return el.ownerDocument.defaultView.pageYOffset;
       }
 
+      function isVisible(element) {
+        return element[0].offsetParent !== null;
+      }
+
       function offsetTop(element) {
         if (!(!element[0].getBoundingClientRect || element.css('none'))) {
           return element[0].getBoundingClientRect().top + pageYOffset(element);
@@ -61,26 +65,31 @@ angular.module(MODULE_NAME, [])
       // with a boolean that is set to true when the function is
       // called in order to throttle the function call.
       function defaultHandler() {
-        let containerBottom;
-        let elementBottom;
-        if (container === windowElement) {
-          containerBottom = height(container) + pageYOffset(container[0].document.documentElement);
-          elementBottom = offsetTop(elem) + height(elem);
-        } else {
-          containerBottom = height(container);
-          let containerTopOffset = 0;
-          if (offsetTop(container) !== undefined) {
-            containerTopOffset = offsetTop(container);
+        let shouldScroll = false;
+
+        if (isVisible(elem)) {
+          let containerBottom;
+          let elementBottom;
+          if (container === windowElement) {
+            containerBottom = height(container) +
+                pageYOffset(container[0].document.documentElement);
+            elementBottom = offsetTop(elem) + height(elem);
+          } else {
+            containerBottom = height(container);
+            let containerTopOffset = 0;
+            if (offsetTop(container) !== undefined) {
+              containerTopOffset = offsetTop(container);
+            }
+            elementBottom = (offsetTop(elem) - containerTopOffset) + height(elem);
           }
-          elementBottom = (offsetTop(elem) - containerTopOffset) + height(elem);
-        }
 
-        if (useDocumentBottom) {
-          elementBottom = height((elem[0].ownerDocument || elem[0].document).documentElement);
-        }
+          if (useDocumentBottom) {
+            elementBottom = height((elem[0].ownerDocument || elem[0].document).documentElement);
+          }
 
-        const remaining = elementBottom - containerBottom;
-        const shouldScroll = remaining <= (height(container) * scrollDistance) + 1;
+          const remaining = elementBottom - containerBottom;
+          shouldScroll = remaining <= (height(container) * scrollDistance) + 1;
+        }
 
         if (shouldScroll) {
           checkWhenEnabled = true;

--- a/test/spec/ng-infinite-scroll.spec.js
+++ b/test/spec/ng-infinite-scroll.spec.js
@@ -250,6 +250,13 @@ function describeTests(angularVersion, container) {
       }
       );
 
+      it('do not trigger when element is invisible', function () {
+        replaceIndexFile("style='display: none;'", throttle);
+        browser.get(pathToDocument);
+        return expect(getItems().count()).toBe(0);
+      }
+      );
+
       return describe('with an event handler', () =>
         it('calls the event handler on an event', retry(16, function () {
           replaceIndexFile("infinite-scroll-listen-for-event='anEvent'", throttle);


### PR DESCRIPTION
An adapted version of #180 for the new code. I also changed the method of determining whether the element is hidden based on [this](https://stackoverflow.com/a/21696585/695503) SO answer, and it has a limitation that the container cannot have fixed positioning. 