### PR TITLE
Allow self container

### DIFF
--- a/src/infinite-scroll.js
+++ b/src/infinite-scroll.js
@@ -247,6 +247,10 @@ angular.module(MODULE_NAME, [])
         changeContainer(angular.element(elem.parent()));
       }
 
+      if (attrs.infiniteScrollSelf != null) {
+        changeContainer(elem);
+      }
+
       // infinte-scoll-immediate-check sets whether or not run the
       // expression passed on infinite-scroll for the first time when the
       // directive first loads, before any actual scroll.


### PR DESCRIPTION
This PR add the optional feature that allow the element self use as container. 

Usage: 

Add `infinite-scroll-self="true"` on the infinite scroll element to the self set as container