### PR TITLE
When using 'infiniteScrollContainer' attribute the calculation isn't according to the chosen container

### DIFF
--- a/src/infinite-scroll.js
+++ b/src/infinite-scroll.js
@@ -67,12 +67,12 @@ angular.module(MODULE_NAME, [])
           containerBottom = height(container) + pageYOffset(container[0].document.documentElement);
           elementBottom = offsetTop(elem) + height(elem);
         } else {
-          containerBottom = height(container);
+          containerBottom = height(container) + container.scrollTop();
           let containerTopOffset = 0;
           if (offsetTop(container) !== undefined) {
             containerTopOffset = offsetTop(container);
           }
-          elementBottom = (offsetTop(elem) - containerTopOffset) + height(elem);
+          elementBottom = (offsetTop(elem) - containerTopOffset) + elem[0].scrollHeight;
         }
 
         if (useDocumentBottom) {


### PR DESCRIPTION
https://github.com/sroze/ngInfiniteScroll/issues/376

While the container isn't the windowElement the calculation isn't relative to the container.
So I fix it to be relative to the chosen container.
